### PR TITLE
Tracing: create empty metadata if none is present.

### DIFF
--- a/trace/wrapper.go
+++ b/trace/wrapper.go
@@ -26,6 +26,7 @@ func (c *clientWrapper) Call(ctx context.Context, req client.Request, rsp interf
 	md, ok := metadata.FromContext(ctx)
 	if !ok {
 		// this is a new span
+		md = metadata.Metadata{}
 		span = c.t.NewSpan(nil)
 	} else {
 		// can we gt the span from the header?


### PR DESCRIPTION
When getting the metadata from the context fails, there is no metadata
passed. This means that when we try to create headers from the metadata,
where we set metadata information, it will try and write to a nil map,
which causes a panic.

This initialises an empty metadata object when it can't create one from
context.